### PR TITLE
Added missing prereq IO::K8s as reported by CPANTS.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'Type::Tiny';
 requires 'Throwable::Error';
 requires 'JSON::MaybeXS';
 requires 'Module::Runtime';
+requires 'IO::K8s';
 
 on test => sub {
   requires 'Test::More';


### PR DESCRIPTION
Hi @pplu 

Please review the PR.
https://cpants.cpanauthors.org/release/JLMARTIN/Kubernetes-REST-0.01

Many Thanks.
Best Regards,
Mohammad S Anwar